### PR TITLE
refactor: 定数化・HTTP クライアント再利用・parseBool 簡略化

### DIFF
--- a/yabumi.go
+++ b/yabumi.go
@@ -21,6 +21,14 @@ var (
 	date    = "unknown"
 )
 
+const (
+	httpTimeout   = 3 * time.Second
+	retryCount    = 3
+	retryBaseWait = time.Second
+)
+
+var httpClient = &http.Client{Timeout: httpTimeout}
+
 type Options struct {
 	Channel         string   `short:"C" long:"channel" description:"slack channel to post"`
 	UseAttach       bool     `short:"a" long:"attachment" description:"use attachment"`
@@ -90,18 +98,12 @@ func parseField(s string) Field {
 }
 
 func parseBool(s string) bool {
-	var result bool
 	switch strings.ToLower(s) {
-	case "0":
-		result = false
-	case "false":
-		result = false
-	case "":
-		result = false
+	case "0", "false", "":
+		return false
 	default:
-		result = true
+		return true
 	}
-	return result
 }
 
 // permanentError はリトライすべきでないエラーを表す
@@ -143,8 +145,7 @@ func postMessage(url string, json []byte) error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: time.Duration(3) * time.Second}
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
@@ -233,7 +234,7 @@ func main() {
 		if opts.Args.Url == "" {
 			log.Fatal("the required argument `Url` was not provided")
 		}
-		if err := sendWithRetry(opts.Args.Url, b, 3, time.Second); err != nil {
+		if err := sendWithRetry(opts.Args.Url, b, retryCount, retryBaseWait); err != nil {
 			log.Fatal("all attempts failed")
 		}
 	}


### PR DESCRIPTION
## 概要

残っていた小規模な改善点をまとめて対応しました。

## 変更内容

### マジックナンバーを定数化
`3`（秒）や `3`（リトライ回数）などのマジックナンバーを定数として定義し、意図を明確にしました。

```go
const (
    httpTimeout   = 3 * time.Second
    retryCount    = 3
    retryBaseWait = time.Second
)
```

### HTTP クライアントの再利用
`postMessage()` を呼ぶたびに `http.Client` を生成していたのを、パッケージレベルの変数として一度だけ初期化するように変更しました。

```go
var httpClient = &http.Client{Timeout: httpTimeout}
```

### `parseBool()` の簡略化
すべて `false` を返す3つの `case` を1行にまとめ、冗長な中間変数も削除しました。

```go
// Before: case "0": result = false / case "false": result = false / ...
// After:
case "0", "false", "":
    return false
```

## テスト

```
$ go test ./...
ok  github.com/yteraoka/yabumi  0.018s
```