### PR TITLE
feat: renovate で minimumReleaseAge を 7 days に設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary

- `minimumReleaseAge: "7 days"` を追加
- パッケージのリリースから7日経過するまで Renovate が PR を作成しないようにする

## Test plan

- [ ] renovate.json の設定が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)