### PR TITLE
Rename homebrew-tap repository to homebrew-cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             yabumi
-            homebrew-tap
+            homebrew-cask
 
       - name: Run GoReleaser release (Tag Push)
         if: startsWith(github.ref, 'refs/tags/')

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,7 @@ changelog:
 homebrew_casks:
   - repository:
       owner: yteraoka
-      name: homebrew-tap
+      name: homebrew-cask
       token: "{{ .Env.GITHUB_TOKEN }}"
       pull_request:
         enabled: false


### PR DESCRIPTION
## Summary
- Update GitHub App token generation to target the `homebrew-cask` repository instead of `homebrew-tap`
- Update GoReleaser homebrew cask config to point at the renamed `homebrew-cask` repository

## Test plan
- [ ] Verify release workflow succeeds and publishes to `homebrew-cask` on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)